### PR TITLE
Fix null messageID getting sent to Juno.

### DIFF
--- a/Stickynote.user.js
+++ b/Stickynote.user.js
@@ -121,7 +121,7 @@ function getMeasures(measure) {
   }
   xmlhttp.open('GET', newURL, false);
   xmlhttp.send();
-  if (measure > - 1) {
+  if (measure > - 1 && mymsgId != '') {
     xmlhttp = new XMLHttpRequest();
     xmlhttp.open('GET', vPath + 'oscarMessenger/ViewMessage.do?messageID=' + mymsgId, false);
     xmlhttp.send();


### PR DESCRIPTION
When viewing the schedule page a request to load a blank messageID was getting sent to Juno. I have simply added a blank check to prevent this. 
Ps. this is in relation to, OHSUPPORT-7093 at CloudPractice. 